### PR TITLE
Adds partial pagination option that skips count

### DIFF
--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -1,0 +1,65 @@
+import { DataTypes, Sequelize } from 'sequelize'
+import { findAndCountAll } from './helpers'
+
+const testData = [
+  {
+    id: 1,
+    field1: 'field 1 value',
+    field2: 'field 2 value',
+  },
+]
+describe('findAndCountAll', () => {
+  const sequelize = new Sequelize('sqlite::memory:')
+
+  const IdModel = sequelize.define(
+    'IdModel',
+    {
+      // Model attributes are defined here
+      id: {
+        type: DataTypes.NUMBER,
+        allowNull: false,
+        primaryKey: true,
+      },
+      field1: {
+        type: DataTypes.STRING,
+      },
+      field2: {
+        type: DataTypes.STRING,
+      },
+    },
+    {
+      modelName: 'IdModel',
+    }
+  )
+
+  beforeAll(async () => {
+    await IdModel.sync()
+    await IdModel.create(testData[0])
+  })
+
+  it('returns correct pagination count', async () => {
+    const { count } = await findAndCountAll(IdModel, {
+      where: {},
+      limit: 2,
+      offset: 0,
+      order: [],
+    })
+    expect(count).toBe(1)
+  })
+
+  it('returns correct partial pagination count', async () => {
+    const { count } = await findAndCountAll(
+      IdModel,
+      {
+        where: {},
+        limit: 2,
+        offset: 0,
+        order: [],
+      },
+      {
+        partialPagination: true,
+      }
+    )
+    expect(count).toBe(1)
+  })
+})

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,40 @@
+import { Model, ModelStatic, WhereOptions } from 'sequelize'
+
+export const findAndCountAll = async <
+  Attributes extends {},
+  CreationAttributes extends {} = Attributes
+>(
+  model: ModelStatic<Model<Attributes, CreationAttributes>>,
+  conf: {
+    where: WhereOptions<Attributes>
+    limit: number
+    offset: number
+    order: Array<[string, string]>
+  },
+  options: { partialPagination?: boolean } = {}
+) => {
+  const { partialPagination } = options
+  const { where, limit, offset, order } = conf
+
+  if (!partialPagination) {
+    return model.findAndCountAll({
+      limit,
+      offset,
+      order,
+      where,
+      raw: true,
+    })
+  }
+  const findAllResult = await model.findAll({
+    limit: limit + 1,
+    offset,
+    order,
+    where,
+    raw: true,
+  })
+
+  return {
+    rows: findAllResult.slice(0, limit),
+    count: offset + findAllResult.length,
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Model, ModelStatic } from 'sequelize'
-import { sequelizeSearchFields } from './searchList';
+import { findAndCountAll } from './helpers'
+import { sequelizeSearchFields } from './searchList'
 export { sequelizeSearchFields }
 
 interface Actions<
@@ -32,7 +33,8 @@ const sequelizeCrud = <
   Attributes extends { id: string | number },
   CreationAttributes extends {} = Attributes
 >(
-  model: ModelStatic<Model<Attributes, CreationAttributes>>
+  model: ModelStatic<Model<Attributes, CreationAttributes>>,
+  options?: { partialPagination?: boolean }
 ): Actions<Attributes, CreationAttributes> => {
   return {
     create: body => model.create(body),
@@ -45,13 +47,11 @@ const sequelizeCrud = <
     },
     getOne: async id => model.findByPk(id),
     getList: async ({ filter, limit, offset, order }) => {
-      return model.findAndCountAll({
-        limit,
-        offset,
-        order,
-        where: filter,
-        raw: true,
-      })
+      return findAndCountAll(
+        model,
+        { where: filter, limit, offset, order },
+        options
+      )
     },
     destroy: async id => {
       const record = await model.findByPk(id)


### PR DESCRIPTION
### Motivation
- When table has few million records count is slow and Sequelize function findAndCountAll takes a lot of time
### Changes
- This PR adds option to pass partialPagination to findAndCountAll that will skip count and only use it to decide if there is next page of records. 